### PR TITLE
Create getZoomFromCoordinates(lat, lon)

### DIFF
--- a/dist/Leaflet.BlurredLocation.js
+++ b/dist/Leaflet.BlurredLocation.js
@@ -662,13 +662,14 @@ BlurredLocation = function BlurredLocation(options) {
   }
 
   function getPrecisionFromCoordinates(lat, lon) {
-    let precisionArr = [getPrecisionFromNum(lat), getPrecisionFromNum(lon)];
-    return precisionArr.sort((a, b) => b-a)[0];
+    var latPrecision = getPrecisionFromNum(lat);
+    var lonPrecision = getPrecisionFromNum(lon);
+    return latPrecision > lonPrecision ? latPrecision : lonPrecision;
   }
 
   function getPrecisionFromNum(num) {
-    let numArr = num.toString().split('.');
-    let precision = 0;
+    var numArr = num.toString().split('.');
+    var precision = 0;
 
     if(numArr.length === 1) {
       if(Math.floor(num/100) == num/100) {
@@ -793,7 +794,6 @@ BlurredLocation = function BlurredLocation(options) {
     $("#"+InterfaceOptions.latId).val(getLat()) ;
     $("#"+InterfaceOptions.lngId).val(getLon()) ; 
   }
-
 
   function setZoomByPrecision(precision) {
     setZoom(options.precisionTable[precision]);

--- a/dist/Leaflet.BlurredLocation.js
+++ b/dist/Leaflet.BlurredLocation.js
@@ -655,6 +655,8 @@ BlurredLocation = function BlurredLocation(options) {
 
   function getZoom() {
     return options.map.getZoom();
+  }
+    
   function getZoomFromCoordinates(lat, lon) {
     return getZoomByPrecision(getPrecisionFromCoordinates(lat, lon));
   }

--- a/dist/Leaflet.BlurredLocation.js
+++ b/dist/Leaflet.BlurredLocation.js
@@ -798,7 +798,6 @@ BlurredLocation = function BlurredLocation(options) {
   }
 
   function getZoomByPrecision(precision) {
-    console.log(options.precisionTable);
     return options.precisionTable[precision];
   }
 

--- a/dist/Leaflet.BlurredLocation.js
+++ b/dist/Leaflet.BlurredLocation.js
@@ -564,6 +564,7 @@ BlurredLocation = function BlurredLocation(options) {
   var blurred = true;
   var DEFAULT_PRECISION = 6;
   require('leaflet-graticule');
+  var default_precision_table = {'-2': 2, '-1': 3, '0':6, '1':10, '2':13, '3':16};
 
   options = options || {};
   options.location = options.location || {
@@ -572,6 +573,8 @@ BlurredLocation = function BlurredLocation(options) {
   };
 
   options.zoom = options.zoom || 6;
+
+  options.precisionTable = options.precisionTable || default_precision_table;
 
   options.mapID = options.mapID || 'map'
 
@@ -627,7 +630,7 @@ BlurredLocation = function BlurredLocation(options) {
   options.blurryScaleNames = options.blurryScaleNames || {
    "urban":["country", "state", "district", "neighborhood","block", "building"],
    "rural":["country", "county", "town", "village", "house", "house"],
- }
+  }
 
   function getLat() {
     if(isBlurred())
@@ -652,6 +655,31 @@ BlurredLocation = function BlurredLocation(options) {
 
   function getZoom() {
     return options.map.getZoom();
+  function getZoomFromCoordinates(lat, lon) {
+    return getZoomByPrecision(getPrecisionFromCoordinates(lat, lon));
+  }
+
+  function getPrecisionFromCoordinates(lat, lon) {
+    let precisionArr = [getPrecisionFromNum(lat), getPrecisionFromNum(lon)];
+    return precisionArr.sort((a, b) => b-a)[0];
+  }
+
+  function getPrecisionFromNum(num) {
+    let numArr = num.toString().split('.');
+    let precision = 0;
+
+    if(numArr.length === 1) {
+      if(Math.floor(num/100) == num/100) {
+        precision = -2;
+      } else if (Math.floor(num/10) == num/10) {
+        precision = -1;
+      } else {
+        precision = 0;
+      }
+    } else {
+      precision = (numArr[1].length >= 3) ? 3 : numArr[1].length;
+    }
+    return precision;
   }
 
   function getSize() {
@@ -766,8 +794,12 @@ BlurredLocation = function BlurredLocation(options) {
 
 
   function setZoomByPrecision(precision) {
-    var precisionTable = {'-2': 2, '-1': 3, '0':6, '1':10, '2':13, '3':16};
-    setZoom(precisionTable[precision]);
+    setZoom(options.precisionTable[precision]);
+  }
+
+  function getZoomByPrecision(precision) {
+    console.log(options.precisionTable);
+    return options.precisionTable[precision];
   }
 
   function enableCenterShade() {
@@ -864,6 +896,9 @@ BlurredLocation = function BlurredLocation(options) {
     getPrecision: getPrecision,
     setZoom: setZoom,
     getZoom: getZoom,
+    getZoomFromCoordinates: getZoomFromCoordinates,
+    getPrecisionFromCoordinates: getPrecisionFromCoordinates,
+    getPrecisionFromNum: getPrecisionFromNum,
     Interface: Interface,
     getFullLon: getFullLon,
     getFullLat: getFullLat,
@@ -873,6 +908,7 @@ BlurredLocation = function BlurredLocation(options) {
     map: options.map,
     updateRectangleOnPan: updateRectangleOnPan,
     setZoomByPrecision: setZoomByPrecision,
+    getZoomByPrecision: getZoomByPrecision,
     disableCenterShade: disableCenterShade,
     enableCenterShade: enableCenterShade,
     geocodeStringAndPan: Geocoding.geocodeStringAndPan,

--- a/examples/index.html
+++ b/examples/index.html
@@ -120,7 +120,8 @@
           lngId: 'lng'
         },
         AddScaleDisplay: true ,
-        AddBlurryScale: true
+        AddBlurryScale: true,
+        precisionTable: {'-2': 2, '-1': 3, '0': 6, '1': 10, '2': 13, '3': 16}
       }
 
       var blurredLocation = new BlurredLocation(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-blurred-location",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "description": "",
   "main": "Gruntfile.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-blurred-location",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "Gruntfile.js",
   "scripts": {

--- a/spec/javascripts/test_spec.js
+++ b/spec/javascripts/test_spec.js
@@ -86,11 +86,16 @@ describe("Basic testing", function() {
 
   it("Checks if setZoomByPrecision pans the map to correct zoom", function() {
     blurredLocation.setZoomByPrecision(2);
-    expect(blurredLocation.getPrecision()).toBe(2);
+    expect(blurredLocation.getZoom()).toBe(13);
     blurredLocation.setZoomByPrecision(1);
-    expect(blurredLocation.getPrecision()).toBe(1);
+    expect(blurredLocation.getZoom()).toBe(10);
   });
 
+  it("Checks if getZoomByPrecision returns the correct zoom", function() {
+    expect(blurredLocation.getZoomByPrecision(2)).toBe(13);
+    expect(blurredLocation.getZoomByPrecision(-1)).toBe(3);
+  });
+  
   it("Checks if getDistanceMetrics returns correct scale", function() {
     blurredLocation.setZoomByPrecision(2);
     expect(blurredLocation.getDistanceMetrics()).toBe(1.41);
@@ -103,5 +108,28 @@ describe("Basic testing", function() {
   //   expect(blurredLocation.getLat()).toBe(-34.6036844);
   //   expect(blurredLocation.getLon()).toBe(-58.3815591);
   // });
+
+  it("Checks if getZoom returns the correct zoom", function() {
+    blurredLocation.setZoom(5);
+    expect(blurredLocation.getZoom()).toBe(5);
+  });
+
+  it("Checks if getPrecisionFromNum returns the correct precision value", function() {
+    expect(blurredLocation.getPrecisionFromNum(5.321)).toBe(3);
+    expect(blurredLocation.getPrecisionFromNum(5)).toBe(0);
+    expect(blurredLocation.getPrecisionFromNum(60)).toBe(-1);
+  });
+
+  it("Checks if getPrecisionFromCoordinates returns the highest precision", function() {
+    expect(blurredLocation.getPrecisionFromCoordinates(5.321, 1.12)).toBe(3);
+    expect(blurredLocation.getPrecisionFromCoordinates(5.32, 10.1)).toBe(2);
+    expect(blurredLocation.getPrecisionFromCoordinates(50, 55)).toBe(0);
+  });
+  
+  it("Checks if getZoomFromCoordinates returns the correct zoom", function() {
+    expect(blurredLocation.getZoomFromCoordinates(5.321, 1.122)).toBe(16);
+    expect(blurredLocation.getZoomFromCoordinates(5.32, 10.15)).toBe(13);
+    expect(blurredLocation.getZoomFromCoordinates(51, 55)).toBe(6);
+  });
 
 });

--- a/src/blurredLocation.js
+++ b/src/blurredLocation.js
@@ -95,6 +95,7 @@ BlurredLocation = function BlurredLocation(options) {
 
   function getZoom() {
     return options.map.getZoom();
+  }
     
   function getZoomFromCoordinates(lat, lon) {
     return getZoomByPrecision(getPrecisionFromCoordinates(lat, lon));

--- a/src/blurredLocation.js
+++ b/src/blurredLocation.js
@@ -239,7 +239,6 @@ BlurredLocation = function BlurredLocation(options) {
   }
 
   function getZoomByPrecision(precision) {
-    console.log(options.precisionTable);
     return options.precisionTable[precision];
   }
 

--- a/src/blurredLocation.js
+++ b/src/blurredLocation.js
@@ -92,6 +92,32 @@ BlurredLocation = function BlurredLocation(options) {
 
   function getZoom() {
     return options.map.getZoom();
+    
+  function getZoomFromCoordinates(lat, lon) {
+    return getZoomByPrecision(getPrecisionFromCoordinates(lat, lon));
+  }
+
+  function getPrecisionFromCoordinates(lat, lon) {
+    let precisionArr = [getPrecisionFromNum(lat), getPrecisionFromNum(lon)];
+    return precisionArr.sort((a, b) => b-a)[0];
+  }
+
+  function getPrecisionFromNum(num) {
+    let numArr = num.toString().split('.');
+    let precision = 0;
+
+    if(numArr.length === 1) {
+      if(Math.floor(num/100) == num/100) {
+        precision = -2;
+      } else if (Math.floor(num/10) == num/10) {
+        precision = -1;
+      } else {
+        precision = 0;
+      }
+    } else {
+      precision = (numArr[1].length >= 3) ? 3 : numArr[1].length;
+    }
+    return precision;
   }
 
   function getSize() {
@@ -210,6 +236,11 @@ BlurredLocation = function BlurredLocation(options) {
     setZoom(precisionTable[precision]);
   }
 
+  function getZoomByPrecision(precision) {
+    var precisionTable = {'-2': 1, '-1': 3, '0':4, '1':10, '2':13, '3':16};
+    return precisionTable[precision];
+  }
+
   function enableCenterShade() {
     options.map.on('move', updateRectangleOnPan);
   }
@@ -304,6 +335,9 @@ BlurredLocation = function BlurredLocation(options) {
     getPrecision: getPrecision,
     setZoom: setZoom,
     getZoom: getZoom,
+    getZoomFromCoordinates: getZoomFromCoordinates,
+    getPrecisionFromCoordinates: getPrecisionFromCoordinates,
+    getPrecisionFromNum: getPrecisionFromNum,
     Interface: Interface,
     getFullLon: getFullLon,
     getFullLat: getFullLat,
@@ -313,6 +347,7 @@ BlurredLocation = function BlurredLocation(options) {
     map: options.map,
     updateRectangleOnPan: updateRectangleOnPan,
     setZoomByPrecision: setZoomByPrecision,
+    getZoomByPrecision: getZoomByPrecision,
     disableCenterShade: disableCenterShade,
     enableCenterShade: enableCenterShade,
     geocodeStringAndPan: Geocoding.geocodeStringAndPan,

--- a/src/blurredLocation.js
+++ b/src/blurredLocation.js
@@ -4,6 +4,7 @@ BlurredLocation = function BlurredLocation(options) {
   var blurred = true;
   var DEFAULT_PRECISION = 6;
   require('leaflet-graticule');
+  var default_precision_table = {'-2': 2, '-1': 3, '0':6, '1':10, '2':13, '3':16};
 
   options = options || {};
   options.location = options.location || {
@@ -12,6 +13,8 @@ BlurredLocation = function BlurredLocation(options) {
   };
 
   options.zoom = options.zoom || 6;
+
+  options.precisionTable = options.precisionTable || default_precision_table;
 
   options.mapID = options.mapID || 'map'
 
@@ -67,7 +70,7 @@ BlurredLocation = function BlurredLocation(options) {
   options.blurryScaleNames = options.blurryScaleNames || {
    "urban":["country", "state", "district", "neighborhood","block", "building"],
    "rural":["country", "county", "town", "village", "house", "house"],
- }
+  }
 
   function getLat() {
     if(isBlurred())
@@ -232,13 +235,12 @@ BlurredLocation = function BlurredLocation(options) {
 
 
   function setZoomByPrecision(precision) {
-    var precisionTable = {'-2': 2, '-1': 3, '0':6, '1':10, '2':13, '3':16};
-    setZoom(precisionTable[precision]);
+    setZoom(options.precisionTable[precision]);
   }
 
   function getZoomByPrecision(precision) {
-    var precisionTable = {'-2': 1, '-1': 3, '0':4, '1':10, '2':13, '3':16};
-    return precisionTable[precision];
+    console.log(options.precisionTable);
+    return options.precisionTable[precision];
   }
 
   function enableCenterShade() {

--- a/src/blurredLocation.js
+++ b/src/blurredLocation.js
@@ -102,13 +102,14 @@ BlurredLocation = function BlurredLocation(options) {
   }
 
   function getPrecisionFromCoordinates(lat, lon) {
-    let precisionArr = [getPrecisionFromNum(lat), getPrecisionFromNum(lon)];
-    return precisionArr.sort((a, b) => b-a)[0];
+    var latPrecision = getPrecisionFromNum(lat);
+    var lonPrecision = getPrecisionFromNum(lon);
+    return latPrecision > lonPrecision ? latPrecision : lonPrecision;
   }
 
   function getPrecisionFromNum(num) {
-    let numArr = num.toString().split('.');
-    let precision = 0;
+    var numArr = num.toString().split('.');
+    var precision = 0;
 
     if(numArr.length === 1) {
       if(Math.floor(num/100) == num/100) {
@@ -233,7 +234,6 @@ BlurredLocation = function BlurredLocation(options) {
     $("#"+InterfaceOptions.latId).val(getLat()) ;
     $("#"+InterfaceOptions.lngId).val(getLon()) ; 
   }
-
 
   function setZoomByPrecision(precision) {
     setZoom(options.precisionTable[precision]);


### PR DESCRIPTION
Fixes #222 

Function takes in a lat and lon and calculates the appropriate zoom level based on the precision of the lat and lon. Returns zoom.

For edge case of lat and lon having a different precision level I checked both lat and lon and took the highest one. I used helper functions `getPrecisionFromCoordinates` and `getPrecisionFromNum`

I also added precisionTable to the API options so an override object can be passed in. The default object currently is:
`var default_precision_table = {'-2': 2, '-1': 3, '0': 6, '1': 10, '2': 13, '3': 16};`
This can later be changed if we decide we want a different format!